### PR TITLE
feat: publish bot state to Redis for nri-flex monitor

### DIFF
--- a/remote-control/internal/discord/discord.go
+++ b/remote-control/internal/discord/discord.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/bwmarrin/discordgo"
@@ -19,6 +20,15 @@ type Bot struct {
 	session *discordgo.Session
 	config  *config.Config
 	redis   *redis.Client
+
+	// Metrics counters consumed by the periodic state writer so the nri-flex
+	// monitor can publish them as ValdiviaIptvRemoteControl events.
+	startTime          time.Time
+	commandsHandled    atomic.Int64
+	autocompletesServed atomic.Int64
+	commandErrors      atomic.Int64
+	lastCommandAt      atomic.Int64 // unix seconds
+	lastCommandName    atomic.Value // string
 }
 
 func NewBot(cfg *config.Config, redisClient *redis.Client, nrApp *newrelic.Application) (*Bot, error) {
@@ -40,9 +50,10 @@ func NewBot(cfg *config.Config, redisClient *redis.Client, nrApp *newrelic.Appli
 	time.Sleep(100 * time.Millisecond)
 
 	return &Bot{
-		session: session,
-		config:  cfg,
-		redis:   redisClient,
+		session:   session,
+		config:    cfg,
+		redis:     redisClient,
+		startTime: time.Now(),
 	}, nil
 }
 
@@ -54,18 +65,25 @@ func (b *Bot) Start(ctx context.Context, config *config.Config, nrApp *newrelic.
 
 	b.session.AddHandler(func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		if i.Type == discordgo.InteractionApplicationCommand {
+			cmdName := i.ApplicationCommandData().Name
+			b.commandsHandled.Add(1)
+			b.lastCommandAt.Store(time.Now().Unix())
+			b.lastCommandName.Store(cmdName)
+
 			cmdTxn := nrApp.StartTransaction("discord:incoming-command")
-			cmdTxn.AddAttribute("command_type", i.ApplicationCommandData().Name)
+			cmdTxn.AddAttribute("command_type", cmdName)
 
 			cmdCtx := newrelic.NewContext(ctx, cmdTxn)
 			err := b.handleApplicationCommand(cmdCtx, s, i, config, nrApp)
 			if err != nil {
+				b.commandErrors.Add(1)
 				cmdTxn.NoticeError(err)
 				log.Printf("error handling command: %v", err)
 			}
 
 			cmdTxn.End()
 		} else if i.Type == discordgo.InteractionApplicationCommandAutocomplete {
+			b.autocompletesServed.Add(1)
 			autocompleteTxn := nrApp.StartTransaction("discord:autocomplete")
 			autocompleteCtx := newrelic.NewContext(ctx, autocompleteTxn)
 
@@ -96,6 +114,10 @@ func (b *Bot) Start(ctx context.Context, config *config.Config, nrApp *newrelic.
 
 	// Start periodic task manager
 	go b.startPeriodicTaskManager(ctx, config, nrApp)
+
+	// Publish a state snapshot to Redis every few seconds for the
+	// nri-flex monitor to scrape.
+	go b.runStateWriter(ctx)
 
 	<-ctx.Done()
 

--- a/remote-control/internal/discord/state_writer.go
+++ b/remote-control/internal/discord/state_writer.go
@@ -1,0 +1,84 @@
+package discord
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"time"
+)
+
+// stateKey is the Redis key under which the bot publishes its current
+// operational state for the nri-flex monitor to scrape via the discord-iptv
+// monitor binary running on the host.
+const stateKey = "remote_control:state"
+
+// stateTTL must be longer than writeStateInterval so a momentary write blip
+// does not cause readers to see "missing".
+const writeStateInterval = 5 * time.Second
+const stateTTL = 30 * time.Second
+
+type remoteControlState struct {
+	Timestamp           int64  `json:"timestamp"`
+	StartTime           int64  `json:"start_time"`
+	UptimeSec           int64  `json:"uptime_sec"`
+	BotReady            bool   `json:"bot_ready"`
+	BotUserID           string `json:"bot_user_id"`
+	BotUserName         string `json:"bot_user_name"`
+	GuildCount          int    `json:"guild_count"`
+	HeartbeatLatencyMs  int64  `json:"heartbeat_latency_ms"`
+	CommandsHandled     int64  `json:"commands_handled"`
+	CommandErrors       int64  `json:"command_errors"`
+	AutocompletesServed int64  `json:"autocompletes_served"`
+	LastCommand         string `json:"last_command"`
+	LastCommandAt       int64  `json:"last_command_at"`
+	CurrentPlaylist     string `json:"current_playlist"`
+}
+
+// runStateWriter periodically serialises the bot's metric state and stores
+// it in Redis so the host-side nri-flex collector can scrape it without
+// having to touch Discord directly.
+func (b *Bot) runStateWriter(ctx context.Context) {
+	ticker := time.NewTicker(writeStateInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := b.writeState(ctx); err != nil {
+				log.Printf("state writer: %v", err)
+			}
+		}
+	}
+}
+
+func (b *Bot) writeState(ctx context.Context) error {
+	now := time.Now()
+	st := remoteControlState{
+		Timestamp:           now.Unix(),
+		StartTime:           b.startTime.Unix(),
+		UptimeSec:           int64(now.Sub(b.startTime).Seconds()),
+		BotReady:            b.session != nil && b.session.State != nil && b.session.State.User != nil,
+		CommandsHandled:     b.commandsHandled.Load(),
+		CommandErrors:       b.commandErrors.Load(),
+		AutocompletesServed: b.autocompletesServed.Load(),
+		LastCommandAt:       b.lastCommandAt.Load(),
+		CurrentPlaylist:     b.getCurrentPlaylist(b.config),
+	}
+	if v, ok := b.lastCommandName.Load().(string); ok {
+		st.LastCommand = v
+	}
+	if st.BotReady {
+		st.BotUserID = b.session.State.User.ID
+		st.BotUserName = b.session.State.User.Username
+		st.GuildCount = len(b.session.State.Guilds)
+		st.HeartbeatLatencyMs = b.session.HeartbeatLatency().Milliseconds()
+	}
+
+	payload, err := json.Marshal(st)
+	if err != nil {
+		return err
+	}
+	return b.redis.SetEx(ctx, stateKey, string(payload), stateTTL)
+}

--- a/remote-control/internal/redis/redis.go
+++ b/remote-control/internal/redis/redis.go
@@ -89,6 +89,18 @@ func (c *Client) instrumentOperation(operationName string, fn func() error) erro
 	return err
 }
 
+// SetEx writes a string value at key with a TTL. Used by the metrics state
+// writer so that a crashed process doesn't leave stale data sitting in Redis.
+func (c *Client) SetEx(ctx context.Context, key, value string, ttl time.Duration) error {
+	return c.rdb.Set(ctx, key, value, ttl).Err()
+}
+
+// PingRaw exposes a thin Ping wrapper for callers that just need to check
+// liveness without going through the instrumented operation pipeline.
+func (c *Client) PingRaw(ctx context.Context) (string, error) {
+	return c.rdb.Ping(ctx).Result()
+}
+
 func (c *Client) StorePlaylist(playlist *models.Playlist, guildID string) error {
 	return c.instrumentOperation("store-playlist", func() error {
 		ctx := context.Background()

--- a/tv-player2/src/index.ts
+++ b/tv-player2/src/index.ts
@@ -42,6 +42,23 @@ const streamer = new Streamer(client);
 let currentAbortController: AbortController | null = null;
 let inVoiceChannel = false;
 
+// Metrics state — periodically flushed to Redis at key `tv_player:state` for the
+// nri-flex monitor. All counters are monotonically increasing since process start.
+const startedAt = Date.now() / 1000;
+let currentTitle = "";
+let currentUrl = "";
+let currentVoiceChannelId = "";
+let streamStartedAt = 0; // epoch seconds while streaming, 0 otherwise
+let totalPlays = 0;
+let totalStops = 0;
+let totalErrors = 0;
+let lastCommandAt = 0;
+let lastCommand = "";
+let lastError = "";
+
+const STATE_KEY = "tv_player:state";
+const STATE_TTL_SEC = 30; // collector reads at most every 30s; expire if we crash
+
 // --- Discord ---
 client.on("ready", async () => {
     console.log(`[discord] Logged in as ${client.user?.tag}`);
@@ -91,6 +108,13 @@ async function handlePlay(title: string, url: string, voiceChannelId: string) {
             newrelic.addCustomAttribute("voiceChannelId", voiceChannelId);
 
             console.log(`[play] Playing "${title}" from ${url} in channel ${voiceChannelId}`);
+
+            totalPlays += 1;
+            currentTitle = title;
+            currentUrl = url;
+            currentVoiceChannelId = voiceChannelId;
+            streamStartedAt = Date.now() / 1000;
+            void writeState();
 
             if (!client.isReady()) {
                 console.warn("[play] Discord client not ready, skipping");
@@ -153,11 +177,15 @@ async function handlePlay(title: string, url: string, voiceChannelId: string) {
                     console.log(`[play] Stream aborted for "${title}"`);
                 } else {
                     newrelic.noticeError(err as Error);
+                    totalErrors += 1;
+                    lastError = (err as Error)?.message ?? String(err);
                     console.error(`[play] Stream error for "${title}":`, err);
                 }
             }
         } catch (err) {
             newrelic.noticeError(err as Error);
+            totalErrors += 1;
+            lastError = (err as Error)?.message ?? String(err);
             console.error(`[play] Unexpected error for "${title}":`, err);
             await handleStop();
         }
@@ -185,6 +213,7 @@ async function stopStream() {
 async function handleStop() {
     return newrelic.startWebTransaction("handle-stop", async () => {
         console.log("[stop] Stopping playback");
+        totalStops += 1;
         await stopStream();
 
         try {
@@ -193,6 +222,11 @@ async function handleStop() {
             // ignore
         }
         inVoiceChannel = false;
+        currentTitle = "";
+        currentUrl = "";
+        currentVoiceChannelId = "";
+        streamStartedAt = 0;
+        void writeState();
 
         console.log("[stop] Playback stopped");
     });
@@ -238,6 +272,10 @@ subClient.on("message", async (_channel: string, raw: string) => {
             console.error("[redis] Message missing command field");
             return;
         }
+
+        lastCommand = msg.command;
+        lastCommandAt = Date.now() / 1000;
+        void writeState();
 
         newrelic.addCustomAttribute("command", msg.command);
         if (msg.title) newrelic.addCustomAttribute("title", msg.title);
@@ -327,6 +365,50 @@ console.log("=== tv-player2 starting ===");
 console.log(`Stream: ${STREAM_WIDTH}x${STREAM_HEIGHT}@${STREAM_FPS}fps ${STREAM_VIDEO_CODEC} ${STREAM_BITRATE_KBPS}kbps`);
 console.log(`Redis: ${REDIS_HOST}:${REDIS_PORT} channel=${REDIS_CHANNEL}`);
 console.log("New Relic monitoring: Enabled");
+
+// Periodic state writer for the nri-flex collector. Writes a JSON snapshot to
+// Redis at `tv_player:state` with TTL so a crashed process doesn't leave stale
+// data lying around forever.
+async function writeState(): Promise<void> {
+    try {
+        const state = {
+            timestamp: Date.now() / 1000,
+            start_time: startedAt,
+            uptime_sec: Math.max(0, Date.now() / 1000 - startedAt),
+            bot_ready: client.isReady(),
+            bot_user_id: client.user?.id ?? "",
+            bot_user_tag: client.user?.tag ?? "",
+            in_voice_channel: inVoiceChannel,
+            voice_channel_id: currentVoiceChannelId,
+            current_title: currentTitle,
+            current_url: currentUrl.substring(0, 256),
+            stream_active: streamStartedAt > 0,
+            stream_started_at: streamStartedAt,
+            stream_uptime_sec: streamStartedAt > 0 ? Math.max(0, Date.now() / 1000 - streamStartedAt) : 0,
+            stream_width: STREAM_WIDTH,
+            stream_height: STREAM_HEIGHT,
+            stream_fps: STREAM_FPS,
+            stream_codec: STREAM_VIDEO_CODEC,
+            stream_bitrate_kbps: STREAM_BITRATE_KBPS,
+            stream_hw_accel: STREAM_HW_ACCEL,
+            total_plays: totalPlays,
+            total_stops: totalStops,
+            total_errors: totalErrors,
+            last_command: lastCommand,
+            last_command_at: lastCommandAt,
+            last_error: lastError.substring(0, 256),
+        };
+        await pubClient.set(STATE_KEY, JSON.stringify(state), "EX", STATE_TTL_SEC);
+    } catch (err) {
+        // Never crash the bot just because metrics write failed.
+        console.error("[metrics] Failed to write state to Redis:", err);
+    }
+}
+
+const stateInterval = setInterval(() => {
+    void writeState();
+}, 5000);
+stateInterval.unref?.();
 
 client.login(TOKEN).catch((err) => {
     console.error("[discord] Login failed:", err);


### PR DESCRIPTION
tv-player2 and remote-control now serialise their current operational state to Redis every 5s with a 30s TTL:

  tv_player:state       — bot ready, current stream (title/url/codec/
                          bitrate/uptime), play/stop/error counters,
                          last command, last error
  remote_control:state  — bot ready, guild count, gateway heartbeat
                          latency, command counters, autocompletes
                          served, last command, current playlist

Changes:

- tv-player2/src/index.ts: in-memory metric vars + writeState() flushed on play/stop/error and on a 5s interval.
- remote-control/internal/discord/discord.go: atomic counters on the Bot struct, instrumented interaction handler, runStateWriter goroutine.
- remote-control/internal/discord/state_writer.go: new file owning the periodic Redis writer.
- remote-control/internal/redis/redis.go: add SetEx + PingRaw helpers.

These keys are read by the discord-iptv-monitor nri-flex collector via docker exec and shipped to New Relic as DiscordIptvTvPlayer and DiscordIptvRemoteControl events.